### PR TITLE
Introduce auto cropping of resulting image

### DIFF
--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -233,6 +233,10 @@ const Tools = {
                             robotCoords.y * settings.scale - robotImage.bitmap.height / 2
                         )
                     }
+                    
+                    // Step 7: Crop image
+                    image.autocrop({ leaveBorder: 20 });
+                    
                     //return results
                     image.getBuffer(Jimp.AUTO, callback);
                 }).catch(err => callback(err));


### PR DESCRIPTION
Removes the same-colored border of resulting images, leaving a fixed arbitrary border behind.

Uses the [`autocrop` feature of `Jimp`](https://github.com/oliver-moran/jimp/blob/master/packages/plugin-crop/README.md)

This is an alternative to manually fidgeting with numbers to finally get a proper-looking cropping.