### PR TITLE
Travis to auto build and deploy docker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+node_js:
+  - lts/*
+dist: trusty
+sudo: true
+
+jobs:
+  include:
+    - stage: deploy
+      node_js: "12"
+      script: "./.travis/deploy.sh"
+      if: type != pull_request AND (branch IN (dev, master) OR tag IS present)
+      addons:
+        apt:
+          sources:
+            - sourceline: deb https://download.docker.com/linux/ubuntu/ xenial stable
+              key_url: https://download.docker.com/linux/ubuntu/gpg
+          packages:
+            - docker-ce
+            - docker-ce-cli
+            - containerd.io

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+  echo "We should not deploy pull requests!"
+  exit 1
+fi
+
+if [ -z "$TRAVIS_TAG" ]; then
+  DOCKER_IMAGE_TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "$TRAVIS_BRANCH-latest"; fi)
+else
+  DOCKER_IMAGE_TAG="$TRAVIS_TAG"
+fi
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+export DOCKER_IMAGE_TAG
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --use
+docker buildx build --progress plain --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8 -t "rand256/valetudo-mapper:$DOCKER_IMAGE_TAG" --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:lts-alpine
 WORKDIR /app
 
 COPY package.json /app
-RUN npm install
+RUN npm install \
+  && touch config.json
 COPY . /app
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Resolves https://github.com/rand256/valetudo/issues/212

You need to create docker hub account. I assumed you will create `rand256` and `valetudo-mapper` repo.

In Travis build settings you will need to setup docker credentials:

![image](https://user-images.githubusercontent.com/2420038/79505931-d26de800-803d-11ea-8c18-4257431bb8b9.png)

After that it should most probably automatically work. It will build and deploy for all kind of architectures on every pushed commit. Use tags in git to pin versions in docker hub.