### PR TITLE
Only persist configuration file if it was changed

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -46,13 +46,16 @@ const Configuration = function(options) {
     if (fs.existsSync(this.location)) {
         console.log("Loading configuration file:", this.location);
         try {
-            this.settings = Object.assign(this.settings, JSON.parse(fs.readFileSync(this.location)));
+            const confFile = JSON.parse(fs.readFileSync(this.location, {flag: 'r'}));
+            this.settings = Object.assign(this.settings, confFile);
             // move mapSettings from mqtt to root if present
             if (this.settings.mqtt.mapSettings) {
                 this.settings.mapSettings = Object.assign(this.settings.mapSettings,this.settings.mqtt.mapSettings);
                 delete this.settings.mqtt.mapSettings;
             }
-            this.persist();
+            if (JSON.stringify(confFile) !== JSON.stringify(this.settings)) {
+                this.persist();
+            }
         } catch(e) {
             console.error(e);
             console.log("JSON is malformed! Fix it or delete the file to get it recreated from scratch.");


### PR DESCRIPTION
Current operation opens the configuration file in read-write mode and updates it no matter if it is the same or not. With this change one can use read-only configuration files provided it is not different when merged with the default configuration.