### PR TITLE
Update MqttClient.js for Home Assistant conformacy

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ if(conf.get("mqtt")) {
         brokerURL: conf.get("mqtt").broker_url,
         caPath: conf.get("mqtt").caPath,
         identifier: conf.get("mqtt").identifier,
+        deviceName: conf.get("mqtt").deviceName,
         topicPrefix: conf.get("mqtt").topicPrefix,
         autoconfPrefix: conf.get("mqtt").autoconfPrefix,
         mapSettings: conf.get("mapSettings"),

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -14,6 +14,7 @@ const Configuration = function(options) {
     this.settings = {
         "mqtt": {
             identifier: "rockrobo",
+            deviceName: "mapper",
             topicPrefix: "valetudo",
             autoconfPrefix: "homeassistant",
             broker_url: "mqtt://user:pass@foobar.example",

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -25,6 +25,7 @@ const MqttClient = function(options) {
     this.brokerURL = options.brokerURL;
     this.caPath = options.caPath || "";
     this.identifier = options.identifier || "rockrobo";
+    this.deviceName = options.deviceName || "mapper";
     this.topicPrefix = options.topicPrefix || "valetudo";
     this.autoconfPrefix = options.autoconfPrefix || "homeassistant";
     this.mapSettings = options.mapSettings || {};
@@ -47,7 +48,7 @@ const MqttClient = function(options) {
         map: {
             name: this.identifier + "_map",
             unique_id: this.identifier + "_map",
-            device: { manufacturer: "Roborock", name: "map", identifiers: [ this.identifier ] },
+            device: { manufacturer: "Roborock", name: this.deviceName, identifiers: [ this.identifier ] },
             topic: this.topics.map
         }
     };

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -47,7 +47,7 @@ const MqttClient = function(options) {
         map: {
             name: this.identifier + "_map",
             unique_id: this.identifier + "_map",
-            device: { manufacturer: "Roborock", name: this.identifier, identifiers: [ this.identifier ] },
+            device: { manufacturer: "Roborock", name: "map", identifiers: [ this.identifier ] },
             topic: this.topics.map
         }
     };


### PR DESCRIPTION
Name and Unique ID shall not be the same, according to [Home Assistant MQTT implementation](https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/). 

Payload will have the Name "map" in this change.
This should remove the warning message in Home Assistant as shown in issue [506](https://github.com/rand256/valetudo/issues/506)

Thanks to [dckiller51](https://github.com/dckiller51) in issue [506](https://github.com/rand256/valetudo/issues/506) of valetudo-re

Remember to restart Home Assistant after updating valetudo.